### PR TITLE
Support for registering agents using SSL certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,50 @@ bosh -e your_bosh_environment update-runtime-config --name=wazuh-agent-addons ma
 ```
 
 Redeploy your initial manifest to make Bosh install and configure the Wazuh Agent on target instances.
+
+
+### Deploy Wazuh Agents using SSL
+
+You can register your Wazuh Agents using SSL  to secure the communication as described in [Agent verification using SSL](https://documentation.wazuh.com/3.9/user-manual/registering/manager-verification/agents/linux-unix-agent-verification.html#linux-and-unix-agents)
+
+To pass your generated `sslagent.cert` and `sslagent.key` files to your runtime configuration you simply have to include them in `wazuh_agent_cert` and `wazuh_agent_key` parameters like in the following example:
+
+
+```yaml
+---
+  releases:
+  - name: "wazuh"
+    version: 3.10.2
+  
+  addons:
+  - name: wazuh
+    release: 3.10.2
+    jobs:
+    - name: wazuh-agent
+      release: wazuh
+      properties:
+          wazuh_server_address: 172.0.3.4
+          wazuh_server_registration_address: 172.0.3.4
+          wazuh_server_protocol: "tcp"
+          wazuh_agents_prefix: "bosh-"
+          wazuh_agent_profile: "generic"
+          wazuh_agent_cert: |
+            -----BEGIN CERTIFICATE-----
+            MIIE6jCCAtICCQCeRsKNJC058zANBgkqhkiG9w0BAQsFADAsMQswCQYDVQQGEwJV
+            UzELMAkGA1UECAwCQ0ExEDAOBgNVBAoMB01hbmFnZXIwHhcNMjAwMjEwMTExNzQ5
+            WhcNMjEwMjA5MTExNzQ5WjBCMQswCQYDVQQGEwJYWDEVMBMGA1UEBwwMRGVmYXVs
+            ...
+            -----END CERTIFICATE-----
+          wazuh_agent_key: |
+            -----BEGIN PRIVATE KEY-----
+            MIIJQQIBADANBgkqhkiG9w0BAQEFAASCCSswggknAgEAAoICAQDgSRkPQbeFBXWE
+            2fG1XZEkJyAVP/wjcuGWRmIufexw/tpVF0+AADhafJwpre+9zYYFDwPeYSN11zAH
+            E5KGDhqDh9hie3xnTOllHfjXbvijuqoLkNUU6HsssGFI/epA1Yfyl220ZNE5AZCL
+            ...
+            -----END PRIVATE KEY-----          
+    exclude:
+      deployments: [wazuh-manager]
+```
+
+This way, your cert and key will be rendered under `/var/vcap/data/packages/wazuh-agent/<random_id>/etc/` and used in the registration process and any communications between the Agent and Manager.
+

--- a/README.md
+++ b/README.md
@@ -102,5 +102,11 @@ To pass your generated `sslagent.cert` and `sslagent.key` files to your runtime 
       deployments: [wazuh-manager]
 ```
 
+Then, update your runtime configuration by executing:
+
+```
+bosh -e your_bosh_environment update-runtime-config --name=wazuh-agent-addons manifest/wazuh-agent.yml
+```
+
 This way, your cert and key will be rendered under `/var/vcap/data/packages/wazuh-agent/<random_id>/etc/` and used in the registration process and any communications between the Agent and Manager.
 

--- a/jobs/wazuh-agent/spec
+++ b/jobs/wazuh-agent/spec
@@ -32,3 +32,9 @@ properties:
   ksc_server_node:
     description: "Set IP address of Kaspersky Security Center. Values: IP.Address"
     default: "10.0.0.83"
+  wazuh_agent_cert_path:
+    description: "Agent's certificate path. Ex: /var/vcap/sslagent.cert"
+    default: ""
+  wazuh_agent_key_path:
+    description: "Agent's key path. Ex: /var/vcap/sslagent.key"
+    default: ""

--- a/jobs/wazuh-agent/spec
+++ b/jobs/wazuh-agent/spec
@@ -14,7 +14,6 @@ templates:
   config/local_internal_options.conf: config/local_internal_options.conf
   config/client.keys.sample: config/client.keys.sample
 
-
 properties:
   wazuh_server_address:
     description: "Wazuh Manager IP or DNS"
@@ -32,9 +31,9 @@ properties:
   ksc_server_node:
     description: "Set IP address of Kaspersky Security Center. Values: IP.Address"
     default: "10.0.0.83"
-  wazuh_agent_cert_path:
+  wazuh_agent_cert:
     description: "Agent's certificate path. Ex: /var/vcap/sslagent.cert"
     default: ""
-  wazuh_agent_key_path:
+  wazuh_agent_key:
     description: "Agent's key path. Ex: /var/vcap/sslagent.key"
     default: ""

--- a/jobs/wazuh-agent/templates/bin/pre-start.erb
+++ b/jobs/wazuh-agent/templates/bin/pre-start.erb
@@ -28,7 +28,7 @@ if [ ! -s ${DATA_DIR}/etc/client.keys ]; then
     if [[ "<%= p("cert_path") %>" != "" && "<%= p("cert_key") %>" != "" ]] ; then
       SSL_CREDS="-x <%= p("cert_path") %> -k <%= p("key_path") %>"
     fi
-    if ${PACKAGE_DIR}/bin/agent-auth -m <%= p("wazuh_server_registration_address") %> -x <%= p("cert_path") %> -k <%= p("key_path") %> -A <%= p("wazuh_agents_prefix") %>`hostname` $SSL_CREDS
+    if ${PACKAGE_DIR}/bin/agent-auth -m <%= p("wazuh_server_registration_address") %> -A <%= p("wazuh_agents_prefix") %>`hostname` $SSL_CREDS
     then
       cp ${PACKAGE_DIR}/etc/client.keys ${DATA_DIR}/etc/
       echo "$TIMESTAMP : INFO : Registration success" >> ${LOG_DIR}/setup.log

--- a/jobs/wazuh-agent/templates/bin/pre-start.erb
+++ b/jobs/wazuh-agent/templates/bin/pre-start.erb
@@ -24,7 +24,11 @@ if [ ! -L ${LOG_DIR}/wazuh_logs ]; then
 fi
 
 if [ ! -s ${DATA_DIR}/etc/client.keys ]; then
-    if ${PACKAGE_DIR}/bin/agent-auth -m <%= p("wazuh_server_registration_address") %> -A <%= p("wazuh_agents_prefix") %>`hostname`
+    SSL_CREDS=""
+    if [[ "<%= p("cert_path") %>" != "" && "<%= p("cert_key") %>" != "" ]] ; then
+      SSL_CREDS="-x <%= p("cert_path") %> -k <%= p("key_path") %>"
+    fi
+    if ${PACKAGE_DIR}/bin/agent-auth -m <%= p("wazuh_server_registration_address") %> -x <%= p("cert_path") %> -k <%= p("key_path") %> -A <%= p("wazuh_agents_prefix") %>`hostname` $SSL_CREDS
     then
       cp ${PACKAGE_DIR}/etc/client.keys ${DATA_DIR}/etc/
       echo "$TIMESTAMP : INFO : Registration success" >> ${LOG_DIR}/setup.log

--- a/jobs/wazuh-agent/templates/bin/pre-start.erb
+++ b/jobs/wazuh-agent/templates/bin/pre-start.erb
@@ -25,19 +25,14 @@ fi
 
 if [ ! -s ${DATA_DIR}/etc/client.keys ]; then
     SSL_CREDS=""
-    if  [[ "<%= p("wazuh_agent_cert_path") %>" != "" ]] && \
-        [[ -f "<%= p("wazuh_agent_cert_path") %>" ]] && \
-        [[ "<%= p("wazuh_agent_key_path") %>" != "" ]] &&  \
-        [[ -f "<%= p("wazuh_agent_key_path") %>" ]] ; then
-
-        cp "<%= p("wazuh_agent_cert_path") %>" ${DATA_DIR}/etc
-        cert_copy_rc=$?
-        cp "<%= p("wazuh_agent_key_path") %>" ${DATA_DIR}/etc
-        key_copy_rc=$?
-        if [[ ${cert_copy_rc} -eq 0 && ${key_copy_rc} -eq 0 ]]; then
-          cert_name=$(basename "<%= p("wazuh_agent_cert_path") %>")
-          key_name=$(basename "<%= p("wazuh_agent_key_path") %>")
-        fi
+    if  [[ "<%= p("wazuh_agent_cert") %>" != "" ]] && \
+        [[ "<%= p("wazuh_agent_key") %>" != "" ]] ; then
+        echo "<%= p("wazuh_agent_cert") %>" > ${PACKAGE_DIR}/etc/sslagent.cert
+        echo "<%= p("wazuh_agent_key") %>" > ${PACKAGE_DIR}/etc/sslagent.key
+        chown root:root ${PACKAGE_DIR}/etc/sslagent.cert ${PACKAGE_DIR}/etc/sslagent.key
+        chmod 400 ${PACKAGE_DIR}/etc/sslagent.cert ${PACKAGE_DIR}/etc/sslagent.key
+        echo "$TIMESTAMP : INFO : Agent cert and key imported succesfully" >> ${LOG_DIR}/setup.log
+        SSL_CREDS="-x ${PACKAGE_DIR}/etc/sslagent.cert -k ${PACKAGE_DIR}/etc/sslagent.key"
     fi
     if ${PACKAGE_DIR}/bin/agent-auth -m "<%= p("wazuh_server_registration_address") %>" -A "<%= p("wazuh_agents_prefix") %>"`hostname` $SSL_CREDS
     then

--- a/jobs/wazuh-agent/templates/bin/pre-start.erb
+++ b/jobs/wazuh-agent/templates/bin/pre-start.erb
@@ -25,10 +25,21 @@ fi
 
 if [ ! -s ${DATA_DIR}/etc/client.keys ]; then
     SSL_CREDS=""
-    if [[ "<%= p("cert_path") %>" != "" && "<%= p("cert_key") %>" != "" ]] ; then
-      SSL_CREDS="-x <%= p("cert_path") %> -k <%= p("key_path") %>"
+    if  [[ "<%= p("wazuh_agent_cert_path") %>" != "" ]] && \
+        [[ -f "<%= p("wazuh_agent_cert_path") %>" ]] && \
+        [[ "<%= p("wazuh_agent_key_path") %>" != "" ]] &&  \
+        [[ -f "<%= p("wazuh_agent_key_path") %>" ]] ; then
+
+        cp "<%= p("wazuh_agent_cert_path") %>" ${DATA_DIR}/etc
+        cert_copy_rc=$?
+        cp "<%= p("wazuh_agent_key_path") %>" ${DATA_DIR}/etc
+        key_copy_rc=$?
+        if [[ ${cert_copy_rc} -eq 0 && ${key_copy_rc} -eq 0 ]]; then
+          cert_name=$(basename "<%= p("wazuh_agent_cert_path") %>")
+          key_name=$(basename "<%= p("wazuh_agent_key_path") %>")
+        fi
     fi
-    if ${PACKAGE_DIR}/bin/agent-auth -m <%= p("wazuh_server_registration_address") %> -A <%= p("wazuh_agents_prefix") %>`hostname` $SSL_CREDS
+    if ${PACKAGE_DIR}/bin/agent-auth -m "<%= p("wazuh_server_registration_address") %>" -A "<%= p("wazuh_agents_prefix") %>"`hostname` $SSL_CREDS
     then
       cp ${PACKAGE_DIR}/etc/client.keys ${DATA_DIR}/etc/
       echo "$TIMESTAMP : INFO : Registration success" >> ${LOG_DIR}/setup.log

--- a/jobs/wazuh-agent/templates/bin/registration.erb
+++ b/jobs/wazuh-agent/templates/bin/registration.erb
@@ -14,8 +14,9 @@ do
   grep bosh-noregistered ${PACKAGE_DIR}/etc/client.keys
   if [[ $? -eq 0 ]] ; then
       SSL_CREDS=""
-      if [[ "<%= p("wazuh_agent_cert_path") %>" != "" && "<%= p("wazuh_agent_key_path") %>" != "" ]] ; then
-        SSL_CREDS="-x <%= p("wazuh_agent_cert_path") %> -k <%= p("wazuh_agent_key_path") %>"
+      if  [[ "<%= p("wazuh_agent_cert") %>" != "" ]] && \
+        [[ "<%= p("wazuh_agent_key") %>" != "" ]] ; then
+        SSL_CREDS="-x ${DATA_DIR}/etc/sslagent.cert -k ${DATA_DIR}/etc/sslagent.key"
       fi
       if ${PACKAGE_DIR}/bin/agent-auth -m <%= p("wazuh_server_registration_address") %> -A <%= p("wazuh_agents_prefix") %>`hostname` $SSL_CREDS
       then

--- a/jobs/wazuh-agent/templates/bin/registration.erb
+++ b/jobs/wazuh-agent/templates/bin/registration.erb
@@ -14,8 +14,8 @@ do
   grep bosh-noregistered ${PACKAGE_DIR}/etc/client.keys
   if [[ $? -eq 0 ]] ; then
       SSL_CREDS=""
-      if [[ "<%= p("cert_path") %>" != "" && "<%= p("cert_key") %>" != "" ]] ; then
-        SSL_CREDS="-x <%= p("cert_path") %> -k <%= p("key_path") %>"
+      if [[ "<%= p("wazuh_agent_cert_path") %>" != "" && "<%= p("wazuh_agent_key_path") %>" != "" ]] ; then
+        SSL_CREDS="-x <%= p("wazuh_agent_cert_path") %> -k <%= p("wazuh_agent_key_path") %>"
       fi
       if ${PACKAGE_DIR}/bin/agent-auth -m <%= p("wazuh_server_registration_address") %> -A <%= p("wazuh_agents_prefix") %>`hostname` $SSL_CREDS
       then

--- a/jobs/wazuh-agent/templates/bin/registration.erb
+++ b/jobs/wazuh-agent/templates/bin/registration.erb
@@ -12,8 +12,12 @@ do
   TIMESTAMP=`date "+%Y-%m-%d %H:%M:%S"`
   # Check if the agent is registered.
   grep bosh-noregistered ${PACKAGE_DIR}/etc/client.keys
-  if [ $? -eq 0 ] ; then
-      if ${PACKAGE_DIR}/bin/agent-auth -m <%= p("wazuh_server_registration_address") %> -A <%= p("wazuh_agents_prefix") %>`hostname`
+  if [[ $? -eq 0 ]] ; then
+      SSL_CREDS=""
+      if [[ "<%= p("cert_path") %>" != "" && "<%= p("cert_key") %>" != "" ]] ; then
+        SSL_CREDS="-x <%= p("cert_path") %> -k <%= p("key_path") %>"
+      fi
+      if ${PACKAGE_DIR}/bin/agent-auth -m <%= p("wazuh_server_registration_address") %> -A <%= p("wazuh_agents_prefix") %>`hostname` $SSL_CREDS
       then
         cp ${PACKAGE_DIR}/etc/client.keys ${DATA_DIR}/etc/
         echo "$TIMESTAMP : INFO : Registration success" >> ${LOG_DIR}/setup.log

--- a/manifest/wazuh-agent.yml
+++ b/manifest/wazuh-agent.yml
@@ -15,7 +15,5 @@
           wazuh_server_protocol: "tcp"
           wazuh_agents_prefix: "bosh-"
           wazuh_agent_profile: "generic"
-          wazuh_agent_cert_path: "/var/vcap/sslagent.cert"
-          wazuh_agent_key_path: "/var/vcap/sslagent.key"
     exclude:
       deployments: [wazuh-manager]

--- a/manifest/wazuh-agent.yml
+++ b/manifest/wazuh-agent.yml
@@ -15,6 +15,8 @@
           wazuh_agents_prefix: "bosh-"
           wazuh_agent_profile: "generic"
           wazuh_server_protocol: "tcp"
+          cert_path: ""
+          key_path: ""
     exclude:
       deployments: [wazuh-manager]
   

--- a/manifest/wazuh-agent.yml
+++ b/manifest/wazuh-agent.yml
@@ -12,11 +12,10 @@
       properties:
           wazuh_server_address: 172.0.3.4
           wazuh_server_registration_address: 172.0.3.4
+          wazuh_server_protocol: "tcp"
           wazuh_agents_prefix: "bosh-"
           wazuh_agent_profile: "generic"
-          wazuh_server_protocol: "tcp"
-          cert_path: ""
-          key_path: ""
+          wazuh_agent_cert_path: "/var/vcap/sslagent.cert"
+          wazuh_agent_key_path: "/var/vcap/sslagent.key"
     exclude:
       deployments: [wazuh-manager]
-  


### PR DESCRIPTION
Hello,

This PR implements the ability to register agents with SSL certificates. It implies the use of the `-x` and `-k` arguments described [here](https://documentation.wazuh.com/3.11/user-manual/reference/tools/agent-auth.html). Now the manifest has these two new parameters: `wazuh_agent_cert` and `wazuh_agent_key`

The job will render the certificate and private key under `/var/ossec/etc`.

Regards