### PR TITLE
Prevent BOSH failures when wazuh-agent jobs stopped

### DIFF
--- a/jobs/wazuh-agent/spec
+++ b/jobs/wazuh-agent/spec
@@ -13,6 +13,7 @@ templates:
   config/preloaded-vars.conf.erb: config/preloaded-vars.conf
   config/local_internal_options.conf: config/local_internal_options.conf
   config/client.keys.sample: config/client.keys.sample
+  helpers/pid_utils.sh: helpers/pid_utils.sh
 
 properties:
   wazuh_server_address:

--- a/jobs/wazuh-agent/templates/bin/wazuh_agent_ctl
+++ b/jobs/wazuh-agent/templates/bin/wazuh_agent_ctl
@@ -5,11 +5,15 @@ set -u # report the usage of uninitialized variables
 
 JOB_NAME=wazuh-agent
 PACKAGE_DIR=/var/vcap/packages/wazuh-agent
+JOB_DIR=/var/vcap/jobs/$JOB_NAME
 STORE_DIR=/var/vcap/store/$JOB_NAME
 RUN_DIR=${PACKAGE_DIR}/var/run
 LOG_DIR=/var/vcap/sys/log/$JOB_NAME
-PIDFILE=${RUN_DIR}/${1}-*.pid
+PIDFILE="${RUN_DIR}/${1}-*.pid"
 
+# Load control helpers
+# shellcheck source=../helpers/pid_utils.sh
+source "${JOB_DIR}/helpers/pid_utils.sh"
 
 case $2 in
 
@@ -23,8 +27,7 @@ case $2 in
 
 
   stop)
-    kill -9 `cat $PIDFILE`
-    rm -rf $PIDFILE
+    kill_and_wait "$PIDFILE"
 
     ;;
   *)

--- a/jobs/wazuh-agent/templates/helpers/pid_utils.sh
+++ b/jobs/wazuh-agent/templates/helpers/pid_utils.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+
+function pid_is_running() {
+  declare pid="$1"
+  ps -p "${pid}" >/dev/null 2>&1
+}
+
+# pid_guard
+#
+# @param pidfile
+# @param name [String] an arbitrary name that might show up in STDOUT on errors
+#
+# Run this before attempting to start new processes that may use the same :pidfile:.
+# If an old process is running on the pid found in the :pidfile:, exit 1. Otherwise,
+# remove the stale :pidfile: if it exists.
+#
+function pid_guard() {
+  declare pidfile="$1" name="$2"
+
+  echo "------------ STARTING $(basename "$0") at $(date) --------------" | tee /dev/stderr
+
+  if [ ! -f "${pidfile}" ]; then
+    return 0
+  fi
+
+  local pid
+  pid=$(head -1 "${pidfile}")
+
+  if pid_is_running "${pid}"; then
+    echo "${name} is already running, please stop it first"
+    exit 1
+  fi
+
+  echo "Removing stale pidfile"
+  rm "${pidfile}"
+}
+
+# wait_pid_death
+#
+# @param pid
+# @param timeout
+#
+# Watch a :pid: for :timeout: seconds, waiting for it to die.
+# If it dies before :timeout:, exit 0. If not, exit 1.
+#
+# Note that this should be run in a subshell, so that the current
+# shell does not exit.
+#
+function wait_pid_death() {
+  declare pid="$1" timeout="$2"
+
+  local countdown
+  countdown=$(( timeout * 10 ))
+
+  while true; do
+    if ! pid_is_running "${pid}"; then
+      return 0
+    fi
+
+    if [ ${countdown} -le 0 ]; then
+      return 1
+    fi
+
+    countdown=$(( countdown - 1 ))
+    sleep 0.1
+  done
+}
+
+# kill_and_wait
+#
+# @param pidfile
+# @param timeout [default 25s]
+#
+# For a pid found in :pidfile:, send a `kill -15` TERM, then wait for :timeout: seconds to
+# see if it dies on its own. If not, send it a `kill -9`. If the process does die,
+# exit 0 and remove the :pidfile:. If after all of this, the process does not actually
+# die, exit 1.
+#
+# Note:
+# Monit default timeout for start/stop is 30s
+# Append 'with timeout {n} seconds' to monit start/stop program configs
+#
+function kill_and_wait() {
+  declare pidfile="$1" timeout="${2:-25}" sigkill_on_timeout="${3:-1}"
+
+  if [ ! -f "${pidfile}" ]; then
+    echo "Pidfile ${pidfile} doesn't exist"
+    exit 0
+  fi
+
+  local pid
+  pid=$(head -1 "${pidfile}")
+
+  if [ -z "${pid}" ]; then
+    echo "Unable to get pid from ${pidfile}"
+    exit 1
+  fi
+
+  if ! pid_is_running "${pid}"; then
+    echo "Process ${pid} is not running"
+    rm -f "${pidfile}"
+    exit 0
+  fi
+
+  echo "Killing ${pidfile}: ${pid} "
+  kill "${pid}"
+
+  if ! wait_pid_death "${pid}" "${timeout}"; then
+    if [ "${sigkill_on_timeout}" = "1" ]; then
+      echo "Kill timed out, using kill -9 on ${pid}"
+      kill -9 "${pid}"
+      sleep 0.5
+    fi
+  fi
+
+  if pid_is_running "${pid}"; then
+    echo "Timed Out"
+    exit 1
+  else
+    echo "Stopped"
+    rm -f "${pidfile}"
+  fi
+}


### PR DESCRIPTION
Hi Team,

In our environment I noticed that BOSH actions sometimes failing to stop with the following error message:
```
Error: Action Failed get_task: Task 6a57682a-0766-4a0c-7001-22dde7dbaaff result: Stopping Monitored Services: Stopping services '[ossec-execd]' errored
```

After further debugging I found out that this issue is happening when job was already stopped (pidfile in `/var/vcap/packages/wazuh-agent/var/run` doesn't exist anymore) and BOSH will try to stop job again:
```
cat: '/var/vcap/packages/wazuh-agent/var/run/ossec-execd-*.pid': No such file or directory
kill: usage: kill [-s sigspec | -n signum | -sigspec] pid | jobspec ... or kill -l [sigspec]
```

Instead of doing `cat && kill -9` I suggest using `wait_and_kill` function from Cloud Foundry CAPI team `pid_utils.sh` script which perform additional checks (doest pidfile exists, etc.) before stopping bosh job.