### PR TITLE
fix(pid_utils): match pidfile from the provided pid_path

### DIFF
--- a/jobs/wazuh-agent/templates/helpers/pid_utils.sh
+++ b/jobs/wazuh-agent/templates/helpers/pid_utils.sh
@@ -68,10 +68,10 @@ function wait_pid_death() {
 
 # kill_and_wait
 #
-# @param pidfile
+# @param pid_path
 # @param timeout [default 25s]
 #
-# For a pid found in :pidfile:, send a `kill -15` TERM, then wait for :timeout: seconds to
+# For a pid found in :pid_path:, send a `kill -15` TERM, then wait for :timeout: seconds to
 # see if it dies on its own. If not, send it a `kill -9`. If the process does die,
 # exit 0 and remove the :pidfile:. If after all of this, the process does not actually
 # die, exit 1.
@@ -81,7 +81,16 @@ function wait_pid_death() {
 # Append 'with timeout {n} seconds' to monit start/stop program configs
 #
 function kill_and_wait() {
-  declare pidfile="$1" timeout="${2:-25}" sigkill_on_timeout="${3:-1}"
+  declare pid_path="$1" timeout="${2:-25}" sigkill_on_timeout="${3:-1}"
+
+  local pidfile
+  # $pid_path needs to be globbed (SC2086)
+  # shellcheck disable=SC2086
+  pidfile=$(ls $pid_path)
+  if [ -z "${pidfile}" ]; then
+    echo "No files matching ${pid_path}"
+    exit 0
+  fi
 
   if [ ! -f "${pidfile}" ]; then
     echo "Pidfile ${pidfile} doesn't exist"


### PR DESCRIPTION
Related to: https://github.com/wazuh/wazuh-bosh/pull/9

kill_and_wait function expects to receive absolute path to pidfile while currently asterisk character used to create the pattern.

```
nats/64ef9fb6-2191-4535-aa3f-504dfd4deba3:/var/vcap/jobs# /var/vcap/jobs/wazuh-agent/bin/wazuh_agent_ctl wazuh-modulesd stop
+ JOB_NAME=wazuh-agent
+ PACKAGE_DIR=/var/vcap/packages/wazuh-agent
+ JOB_DIR=/var/vcap/jobs/wazuh-agent
+ STORE_DIR=/var/vcap/store/wazuh-agent
+ RUN_DIR=/var/vcap/packages/wazuh-agent/var/run
+ LOG_DIR=/var/vcap/sys/log/wazuh-agent
+ PIDFILE='/var/vcap/packages/wazuh-agent/var/run/wazuh-modulesd-*.pid'
+ source /var/vcap/jobs/wazuh-agent/helpers/pid_utils.sh
+ case $2 in
+ kill_and_wait '/var/vcap/packages/wazuh-agent/var/run/wazuh-modulesd-*.pid'
+ declare 'pidfile=/var/vcap/packages/wazuh-agent/var/run/wazuh-modulesd-*.pid' timeout=25 sigkill_on_timeout=1
+ '[' '!' -f '/var/vcap/packages/wazuh-agent/var/run/wazuh-modulesd-*.pid' ']'
+ echo 'Pidfile /var/vcap/packages/wazuh-agent/var/run/wazuh-modulesd-*.pid doesn'\''t exist'
Pidfile /var/vcap/packages/wazuh-agent/var/run/wazuh-modulesd-*.pid doesn't exist
+ exit 0
```

This commit adds additional check to kill_and_wait function that will find an absolute path to the process pidfile. If the pidfile is not found, which means that process is not running, then the function will return exit code 0.

<details><summary>Manual Test</summary>
<p>

```
# /var/vcap/jobs/wazuh-agent/bin/wazuh_agent_ctl wazuh-modulesd stop
+ JOB_NAME=wazuh-agent
+ PACKAGE_DIR=/var/vcap/packages/wazuh-agent
+ JOB_DIR=/var/vcap/jobs/wazuh-agent
+ STORE_DIR=/var/vcap/store/wazuh-agent
+ RUN_DIR=/var/vcap/packages/wazuh-agent/var/run
+ LOG_DIR=/var/vcap/sys/log/wazuh-agent
+ PIDFILE='/var/vcap/packages/wazuh-agent/var/run/wazuh-modulesd-*.pid'
+ source /var/vcap/jobs/wazuh-agent/helpers/pid_utils.sh
+ case $2 in
+ kill_and_wait '/var/vcap/packages/wazuh-agent/var/run/wazuh-modulesd-*.pid'
+ declare 'pid_path=/var/vcap/packages/wazuh-agent/var/run/wazuh-modulesd-*.pid' timeout=25 sigkill_on_timeout=1
+ local pidfile
++ ls /var/vcap/packages/wazuh-agent/var/run/wazuh-modulesd-16148.pid
+ pidfile=/var/vcap/packages/wazuh-agent/var/run/wazuh-modulesd-16148.pid
+ '[' -z /var/vcap/packages/wazuh-agent/var/run/wazuh-modulesd-16148.pid ']'
+ '[' '!' -f /var/vcap/packages/wazuh-agent/var/run/wazuh-modulesd-16148.pid ']'
+ local pid
++ head -1 /var/vcap/packages/wazuh-agent/var/run/wazuh-modulesd-16148.pid
+ pid=16148
+ '[' -z 16148 ']'
+ pid_is_running 16148
+ declare pid=16148
+ ps -p 16148
+ echo 'Killing /var/vcap/packages/wazuh-agent/var/run/wazuh-modulesd-16148.pid: 16148 '
Killing /var/vcap/packages/wazuh-agent/var/run/wazuh-modulesd-16148.pid: 16148
+ kill 16148
+ wait_pid_death 16148 25
+ declare pid=16148 timeout=25
+ local countdown
+ countdown=250
+ true
+ pid_is_running 16148
+ declare pid=16148
+ ps -p 16148
+ return 0
+ pid_is_running 16148
+ declare pid=16148
+ ps -p 16148
+ echo Stopped
Stopped
+ rm -f /var/vcap/packages/wazuh-agent/var/run/wazuh-modulesd-16148.pid
+ exit 0
```

</p>
</details>